### PR TITLE
Add Undo & Redo Commands

### DIFF
--- a/docs/team/jefrai.md
+++ b/docs/team/jefrai.md
@@ -1,8 +1,4 @@
----
-layout: page
-title: Jeff's Project Portfolio Page
----
-
+# Jeff's Project Portfolio Page
 ### Project: AddressBook Level 3
 
 AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,7 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_UNEXISTING_TAG =
-            "There are no tag with name provided exists in the person at the given index!";
+    public static final String MESSAGE_NONEXISTENT_TAG = "That person does not have the provided tag!";
 
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -14,6 +14,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.StateHistory;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -26,6 +27,7 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
+    private final StateHistory history;
     private final AddressBookParser addressBookParser;
 
     /**
@@ -34,6 +36,7 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
+        history = new StateHistory(model);
         addressBookParser = new AddressBookParser();
     }
 
@@ -43,7 +46,9 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
+        command.setHistory(history);
         commandResult = command.execute(model);
+        history.addCommand(command, model, commandResult);
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INCOME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -24,12 +25,14 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_INCOME + "INCOME "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_INCOME + "108000 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
@@ -55,7 +58,7 @@ public class AddCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -17,6 +17,6 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, true, true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -9,6 +9,11 @@ import seedu.address.model.StateHistory;
  */
 public abstract class Command {
 
+    /**
+     * Sets the StateHistory for this command to refer to.
+     *
+     * @param history StateHistory to use
+     */
     public void setHistory(StateHistory history) {
         // Do nothing
     }

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -2,11 +2,16 @@ package seedu.address.logic.commands;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.StateHistory;
 
 /**
  * Represents a command with hidden internal logic and the ability to be executed.
  */
 public abstract class Command {
+
+    public void setHistory(StateHistory history) {
+        // Do nothing
+    }
 
     /**
      * Executes the command and returns the result message.

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -82,13 +82,15 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
+                && undoable == otherCommandResult.undoable
+                && deterministic == otherCommandResult.deterministic
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, undoable, deterministic, showHelp, exit);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -17,21 +17,31 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** Command is undoable and can be saved to undo & redo history. */
+    private final boolean undoable;
+
+    /** Command only ever produces one resultant Model state, for any given initial Model state.
+     * (If false, a snapshot of Model must be taken afterwards to safely redo this Command.) */
+    private final boolean deterministic;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean undoable, boolean deterministic,
+                         boolean showHelp, boolean exit) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.undoable = undoable;
+        this.deterministic = deterministic;
     }
 
     /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and other fields set to their default value.
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code undoable},
+     * and {@code deterministic}, with other fields set to their default value.
      */
-    public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+    public CommandResult(String feedbackToUser, boolean undoable, boolean deterministic) {
+        this(feedbackToUser, undoable, deterministic, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -44,6 +54,14 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isUndoable() {
+        return undoable;
+    }
+
+    public boolean isDeterministic() {
+        return deterministic;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -20,8 +20,10 @@ public class CommandResult {
     /** Command is undoable and can be saved to undo & redo history. */
     private final boolean undoable;
 
-    /** Command only ever produces one resultant Model state, for any given initial Model state.
-     * (If false, a snapshot of Model must be taken afterwards to safely redo this Command.) */
+    /**
+     * Command only ever produces one resultant Model state, given the initial Model state.
+     * (If false, a snapshot of Model must be taken afterwards to safely redo this Command.)
+     */
     private final boolean deterministic;
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -41,7 +41,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete), true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -51,11 +51,11 @@ public class DeleteTagCommand extends Command {
         Person deleteFromPerson = lastShownList.get(targetIndex.getZeroBased());
         //check if the tag with the given name exist
         if (!deleteFromPerson.getTags().contains(tagToDelete)) {
-            throw new CommandException(Messages.MESSAGE_UNEXISTING_TAG);
+            throw new CommandException(Messages.MESSAGE_NONEXISTENT_TAG);
         }
 
         model.deleteTag(deleteFromPerson, tagToDelete);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, deleteFromPerson));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, deleteFromPerson), true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -84,7 +84,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson), true, true);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, false, true);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -41,7 +41,7 @@ public class ExportCommand extends Command {
             }
         }
 
-        return new CommandResult("Exported to file");
+        return new CommandResult("Exported to file", false, false);
     }
 
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -42,7 +42,8 @@ public class FilterCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
+                true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,7 +30,8 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
+                true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, false, false, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,6 +19,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, true, true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+import seedu.address.model.StateHistory;
+
+/**
+ * Redoes a number of the recently undone {@code Command}s.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Redoes the last undone command,"
+            + "or a number of the most recently undone commands.\n"
+            + "Parameters: [NUMBER_OF_COMMANDS]...\n"
+            + "Example: " + COMMAND_WORD + " 5";
+
+    public static final String MESSAGE_SUCCESS = "Redone %1$d / %2$d commands";
+
+    private final int numCommands;
+    private StateHistory history = null;
+
+    /**
+     * Creates an RedoCommand to redo a given number of undone Commands.
+     *
+     * @param numCommands Number of commands to redo
+     */
+    public RedoCommand(int numCommands) {
+        this.numCommands = numCommands;
+    }
+
+    @Override
+    public void setHistory(StateHistory history) {
+        this.history = history;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        requireNonNull(history);
+        int redoneCommands = history.redo(numCommands);
+        Model redoneModel = history.presentModel();
+        model.setAddressBook(redoneModel.getAddressBook());
+        model.updateFilteredPersonList(redoneModel.getPredicate());
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, redoneCommands, numCommands), false, false);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RedoCommand // instanceof handles nulls
+                && numCommands == ((RedoCommand) other).numCommands); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -50,7 +50,7 @@ public class TagCommand extends Command {
 
         Person personToTag = lastShownList.get(targetIndex.getZeroBased());
         model.addTag(personToTag, tagToAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, personToTag));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, personToTag), true, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -6,13 +6,13 @@ import seedu.address.model.Model;
 import seedu.address.model.StateHistory;
 
 /**
- * Finds and lists all persons in the address book whose field entries each match at least one of the provided regexes.
+ * Undoes a number of the most recent prior {@code Command}s.
  */
 public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the previous command or a number of most "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the previous command, or a number of most "
             + "recent commands. Ignores Undo, Redo, and Export commands; affects all other valid commands.\n"
             + "Parameters: [NUMBER_OF_COMMANDS]...\n"
             + "Example: " + COMMAND_WORD + " 5";
@@ -25,7 +25,7 @@ public class UndoCommand extends Command {
     /**
      * Creates an UndoCommand to undo a given number of previous Commands.
      *
-     * @param predicate The predicate
+     * @param numCommands Number of commands to undo
      */
     public UndoCommand(int numCommands) {
         this.numCommands = numCommands;

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+import seedu.address.model.StateHistory;
+
+/**
+ * Finds and lists all persons in the address book whose field entries each match at least one of the provided regexes.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undoes the previous command or a number of most "
+            + "recent commands. Ignores Undo, Redo, and Export commands; affects all other valid commands.\n"
+            + "Parameters: [NUMBER_OF_COMMANDS]...\n"
+            + "Example: " + COMMAND_WORD + " 5";
+
+    public static final String MESSAGE_SUCCESS = "Undone %1$d / %2$d commands";
+
+    private final int numCommands;
+    private StateHistory history = null;
+
+    /**
+     * Creates an UndoCommand to undo a given number of previous Commands.
+     *
+     * @param predicate The predicate
+     */
+    public UndoCommand(int numCommands) {
+        this.numCommands = numCommands;
+    }
+
+    @Override
+    public void setHistory(StateHistory history) {
+        this.history = history;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        requireNonNull(history);
+        int undoneCommands = history.undo(numCommands);
+        Model undoneModel = history.presentModel();
+        model.setAddressBook(undoneModel.getAddressBook());
+        model.updateFilteredPersonList(undoneModel.getPredicate());
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, undoneCommands, numCommands), false, false);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UndoCommand // instanceof handles nulls
+                && numCommands == ((UndoCommand) other).numCommands); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -87,6 +88,9 @@ public class AddressBookParser {
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommandParser().parse(arguments);
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.TagCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -83,6 +84,9 @@ public class AddressBookParser {
 
         case FilterCommand.COMMAND_WORD:
             return new FilterCommandParser().parse(arguments);
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,6 +37,22 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static int parseCommandCount(String count) throws ParseException {
+        String trimmedCount = count.trim();
+        if (trimmedCount.isBlank()) {
+            return 1;
+        }
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedCount)) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
+        return Integer.parseInt(trimmedCount);
+    }
+
+    /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/RedoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RedoCommandParser.java
@@ -2,29 +2,26 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.StateHistory;
 
 /**
- * Parses input arguments and creates a new UndoCommand object
+ * Parses input arguments and creates a new RedoCommand object
  */
-public class UndoCommandParser implements Parser<UndoCommand> {
+public class RedoCommandParser implements Parser<RedoCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the UndoCommand
      * and returns a UndoCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public UndoCommand parse(String args) throws ParseException {
+    public RedoCommand parse(String args) throws ParseException {
         try {
             int count = ParserUtil.parseCommandCount(args);
-            return new UndoCommand(count);
+            return new RedoCommand(count);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RedoCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -2,11 +2,8 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.StateHistory;
 
 /**
  * Parses input arguments and creates a new UndoCommand object

--- a/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UndoCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.StateHistory;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class UndoCommandParser implements Parser<UndoCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UndoCommand
+     * and returns a UndoCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UndoCommand parse(String args) throws ParseException {
+        try {
+            int count = ParserUtil.parseCommandCount(args);
+            return new UndoCommand(count);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -13,7 +13,7 @@ import seedu.address.model.tag.Tag;
  * Wraps all data at the address-book level
  * Duplicates are not allowed (by .isSamePerson comparison)
  */
-public class AddressBook implements ReadOnlyAddressBook {
+public class AddressBook implements ReadOnlyAddressBook, DeepCopyable<AddressBook> {
 
     private final UniquePersonList persons;
 
@@ -114,6 +114,15 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+    @Override
+    public AddressBook deepCopy() {
+        AddressBook copy = new AddressBook();
+        for (Person p: persons.asUnmodifiableObservableList()) {
+            copy.addPerson(p.deepCopy());
+        }
+        return copy;
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/DeepCopyable.java
+++ b/src/main/java/seedu/address/model/DeepCopyable.java
@@ -1,0 +1,5 @@
+package seedu.address.model;
+
+public interface DeepCopyable<T> {
+    public T deepCopy();
+}

--- a/src/main/java/seedu/address/model/DeepCopyable.java
+++ b/src/main/java/seedu/address/model/DeepCopyable.java
@@ -1,5 +1,10 @@
 package seedu.address.model;
 
+/**
+ * Represents that an implementing Object can be deep (mutation-independently) copied into a {@code T}.
+ *
+ * @param <T> The type to copy into
+ */
 public interface DeepCopyable<T> {
     public T deepCopy();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,11 +84,19 @@ public interface Model {
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredPersonList(Predicate<Person> predicate);
+    void updateFilteredPersonList(Predicate<? super Person> predicate);
+
+    Predicate<? super Person> getPredicate();
+
+    /** Returns a state-detached copy of this Model.
+     * The copy (and its composition-descendant Objects) shall not be affected
+     * by {@code Commands} applied to this Model Object.
+     */
+    Model stateDetachedCopy();
 
     /**
-     * Adds the given tag to the person
-     * Person must already exist in the address book
+     * Adds the given tag to the person.
+     * {@code person} must already exist in the address book
      */
     void addTag(Person person, Tag tag);
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -88,7 +88,8 @@ public interface Model {
 
     Predicate<? super Person> getPredicate();
 
-    /** Returns a state-detached copy of this Model.
+    /**
+     * Returns a state-detached copy of this Model.
      * The copy (and its composition-descendant Objects) shall not be affected
      * by {@code Commands} applied to this Model Object.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -35,7 +35,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        filteredPersons.setPredicate(p -> true);
+        filteredPersons.setPredicate(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -35,6 +35,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredPersons.setPredicate(p -> true);
     }
 
     public ModelManager() {
@@ -122,6 +123,13 @@ public class ModelManager implements Model {
         addressBook.deleteTag(person, tag);
     }
 
+    @Override
+    public ModelManager stateDetachedCopy() {
+        ModelManager copy = new ModelManager(addressBook.deepCopy(), userPrefs);
+        copy.updateFilteredPersonList(filteredPersons.getPredicate());
+        return copy;
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -134,9 +142,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredPersonList(Predicate<Person> predicate) {
+    public void updateFilteredPersonList(Predicate<? super Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public Predicate<? super Person> getPredicate() {
+        return filteredPersons.getPredicate();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/StateHistory.java
+++ b/src/main/java/seedu/address/model/StateHistory.java
@@ -9,14 +9,27 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 
+/**
+ * Records past (& future) {@code Model} states and {@code Command}s, such that the {@code Model} state at any point
+ * on the timeline can be reconstructed.
+ */
 public class StateHistory {
+
+    /**
+     * Default number of commands between {@code Model} state snapshots.
+     * Snapshots may be taken at smaller intervals to handle non-deterministic {@code Command}s.
+     */
+    public static final int HISTORY_DEFAULT_INTERVAL = 10;
+
     private int now;
     private final TreeMap<Integer, Model> modelHistory;
     private final TreeMap<Integer, Command> commandHistory;
 
-    /** Default number of commands between Model snapshots, when not forced to take additional snapshots. */
-    public static final int HISTORY_DEFAULT_INTERVAL = 10;
-
+    /**
+     * Creates a {@code StateHistory} with timeline rooted at the given {@code Model}.
+     *
+     * @param initial {@code Model} to begin timeline with
+     */
     public StateHistory(Model initial) {
         now = 0;
         modelHistory = new TreeMap<>();
@@ -24,6 +37,9 @@ public class StateHistory {
         commandHistory = new TreeMap<>();
     }
 
+    /**
+     * Clears all future events after {@code now}, to make way for a split Redo timeline.
+     */
     private void clearFuture() {
         while (modelHistory.ceilingKey(now + 1) != null) {
             modelHistory.remove(modelHistory.ceilingKey(now + 1));
@@ -33,6 +49,14 @@ public class StateHistory {
         }
     }
 
+    /**
+     * Adds {@code command} to the timeline, immediately after the present time.
+     * Any existing future events will be discarded and can no longer be redone.
+     *
+     * @param command {@code Command} to add to timeline
+     * @param model {@code Model} after the execution of {@code command}
+     * @param result {@code CommandResult} of the execution of {@code command}
+     */
     public void addCommand(Command command, Model model, CommandResult result) {
         if (!result.isUndoable()) {
             return;
@@ -46,6 +70,12 @@ public class StateHistory {
         }
     }
 
+    /**
+     * Retrieves the state of the Model at the effective present time.
+     * The returned Model is a deep copy and may be mutated freely.
+     *
+     * @return the Model state at the present time
+     * */
     public Model presentModel() {
         int time = modelHistory.floorKey(now);
         Model model = modelHistory.get(time).stateDetachedCopy();
@@ -60,6 +90,14 @@ public class StateHistory {
         return model;
     }
 
+    /**
+     * Undoes {@code steps} commands, moving the effective present time as many commands backwards.
+     * If fewer than {@code steps} commands can be undone, the maximum possible number smaller than {@code steps}
+     * will be undone instead.
+     *
+     * @param steps number of commands to undo
+     * @return number of commands which were successfully undone
+     */
     public int undo(int steps) {
         int stop = max(now - steps, modelHistory.firstKey());
         int res = now - stop;
@@ -67,6 +105,14 @@ public class StateHistory {
         return res;
     }
 
+    /**
+     * Redoes {@code steps} commands, moving the effective present time as many commands forwards.
+     * If fewer than {@code steps} commands can be redone, the maximum possible number smaller than {@code steps}
+     * will be redone instead.
+     *
+     * @param steps number of commands to redo
+     * @return number of commands which were successfully redone
+     */
     public int redo(int steps) {
         int stop = min(now + steps, !commandHistory.isEmpty() ? commandHistory.lastKey() : 0);
         int res = stop - now;

--- a/src/main/java/seedu/address/model/StateHistory.java
+++ b/src/main/java/seedu/address/model/StateHistory.java
@@ -1,0 +1,76 @@
+package seedu.address.model;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.util.TreeMap;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+
+public class StateHistory {
+    private int now;
+    private final TreeMap<Integer, Model> modelHistory;
+    private final TreeMap<Integer, Command> commandHistory;
+
+    /** Default number of commands between Model snapshots, when not forced to take additional snapshots. */
+    public static final int HISTORY_DEFAULT_INTERVAL = 10;
+
+    public StateHistory(Model initial) {
+        now = 0;
+        modelHistory = new TreeMap<>();
+        modelHistory.put(0, initial.stateDetachedCopy());
+        commandHistory = new TreeMap<>();
+    }
+
+    private void clearFuture() {
+        while (modelHistory.ceilingKey(now + 1) != null) {
+            modelHistory.remove(modelHistory.ceilingKey(now + 1));
+        }
+        while (commandHistory.ceilingKey(now + 1) != null) {
+            commandHistory.remove(commandHistory.ceilingKey(now + 1));
+        }
+    }
+
+    public void addCommand(Command command, Model model, CommandResult result) {
+        if (!result.isUndoable()) {
+            return;
+        }
+        clearFuture();
+        now++;
+        commandHistory.put(now, command);
+        assert !modelHistory.isEmpty() : "modelHistory should never be empty";
+        if (result.isDeterministic() || modelHistory.lastKey() <= now - HISTORY_DEFAULT_INTERVAL) {
+            modelHistory.put(now, model.stateDetachedCopy());
+        }
+    }
+
+    public Model presentModel() {
+        int time = modelHistory.floorKey(now);
+        Model model = modelHistory.get(time).stateDetachedCopy();
+        while (time < now) {
+            time++;
+            try {
+                commandHistory.get(time).execute(model);
+            } catch (CommandException ex) {
+                assert false : "Deterministic command failed on playback";
+            }
+        }
+        return model;
+    }
+
+    public int undo(int steps) {
+        int stop = max(now - steps, modelHistory.firstKey());
+        int res = now - stop;
+        now = stop;
+        return res;
+    }
+
+    public int redo(int steps) {
+        int stop = min(now + steps, commandHistory.lastKey());
+        int res = stop - now;
+        now = stop;
+        return res;
+    }
+}

--- a/src/main/java/seedu/address/model/StateHistory.java
+++ b/src/main/java/seedu/address/model/StateHistory.java
@@ -68,7 +68,7 @@ public class StateHistory {
     }
 
     public int redo(int steps) {
-        int stop = min(now + steps, commandHistory.lastKey());
+        int stop = min(now + steps, !commandHistory.isEmpty() ? commandHistory.lastKey() : 0);
         int res = stop - now;
         now = stop;
         return res;

--- a/src/main/java/seedu/address/model/person/Income.java
+++ b/src/main/java/seedu/address/model/person/Income.java
@@ -4,11 +4,11 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's address in the address book.
+ * Represents a Person's income in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
 public class Income {
-    public static final String MESSAGE_CONSTRAINTS = "income can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Incomes can take any integer values, and it should not be blank";
 
     public final Integer income;
 
@@ -24,7 +24,7 @@ public class Income {
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid income.
      */
     public static boolean isValidIncome(String test) {
         try {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.address.model.DeepCopyable;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -14,7 +15,7 @@ import seedu.address.model.tag.Tag;
  * Guarantees: details are present and not null, field values are validated,
  * immutable.
  */
-public class Person {
+public class Person implements DeepCopyable<Person> {
 
     // Identity fields
     private final Name name;
@@ -23,7 +24,7 @@ public class Person {
     private final Income income;
     // Data fields
     private final Address address;
-    private Set<Tag> tags = new HashSet<>();
+    private HashSet<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
@@ -94,6 +95,10 @@ public class Person {
 
         return otherPerson != null
                 && otherPerson.getName().equals(getName());
+    }
+
+    public Person deepCopy() {
+        return new Person(name, phone, email, address, income, tags);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -145,7 +145,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
+        public void updateFilteredPersonList(Predicate<? super Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -140,6 +140,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public Model stateDetachedCopy() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Predicate<? super Person> getPredicate() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
 public class CommandResultTest {
     @Test
     public void equals() {
-        CommandResult commandResult = new CommandResult("feedback");
+        CommandResult commandResult = new CommandResult("feedback", true, true);
 
         // same values -> returns true
-        assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", true, true)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", true, true, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -26,29 +26,41 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(0.5f));
 
         // different feedbackToUser value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("different")));
+        assertFalse(commandResult.equals(new CommandResult("different", true, true)));
+
+        // different undoable value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false)));
+
+        // different deterministic value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false)));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, true, true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, true, false, true)));
     }
 
     @Test
     public void hashcode() {
-        CommandResult commandResult = new CommandResult("feedback");
+        CommandResult commandResult = new CommandResult("feedback", true, true);
 
         // same values -> returns same hashcode
-        assertEquals(commandResult.hashCode(), new CommandResult("feedback").hashCode());
+        assertEquals(commandResult.hashCode(), new CommandResult("feedback", true, true).hashCode());
 
         // different feedbackToUser value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("different", true, true).hashCode());
+
+        // different undoable value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false, false).hashCode());
+
+        // different deterministic value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false, false).hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, true, true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, true, false, true).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -99,7 +99,7 @@ public class CommandTestUtil {
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
             Model expectedModel) {
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage, true, true);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,8 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false,false, true);
+        CommandResult expectedCommandResult =
+                new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false,false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, false, false, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -1,0 +1,102 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.StateHistory;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
+
+public class RedoCommandTest {
+
+    @Test
+    public void execute_noCommands_success() {
+        String expectedMessage = String.format(RedoCommand.MESSAGE_SUCCESS, 0, 1);
+        Model model = new ModelManager();
+        StateHistory history = new StateHistory(model);
+        Model expectedModel = new ModelManager();
+        RedoCommand redoCommand = new RedoCommand(1);
+        redoCommand.setHistory(history);
+        assertCommandSuccess(redoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
+    }
+
+    @Test
+    public void execute_addDeleteCommands_success() throws CommandException {
+        Command[] commands = new Command[6];
+        commands[0] = new AddCommand(DANIEL);
+        commands[1] = new AddCommand(GEORGE);
+        commands[2] = new AddCommand(ALICE);
+        commands[3] = new DeleteCommand(Index.fromZeroBased(0));
+        commands[4] = new AddCommand(CARL);
+        commands[5] = new AddCommand(ELLE);
+
+        Model expectedModel = new ModelManager();
+        for (int i = 0; i <= commands.length; i++) {
+            String expectedMessage =
+                    String.format(RedoCommand.MESSAGE_SUCCESS, i, i);
+
+            Model model = new ModelManager();
+            StateHistory history = new StateHistory(model);
+            for (Command command : commands) {
+                CommandResult rs = command.execute(model);
+                history.addCommand(command, model, rs);
+            }
+            history.undo(commands.length);
+            RedoCommand redoCommand = new RedoCommand(i);
+            redoCommand.setHistory(history);
+            assertCommandSuccess(redoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
+
+            if (i < commands.length) {
+                commands[i].execute(expectedModel);
+            }
+        }
+    }
+
+    @Test
+    public void execute_predicateCommands_success() throws CommandException {
+        Command[] commands = new Command[9];
+        commands[0] = new AddCommand(DANIEL);
+        commands[1] = new AddCommand(GEORGE);
+        commands[2] = new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("GEORGE")));
+        commands[3] = new AddCommand(ALICE);
+        commands[4] = new DeleteCommand(Index.fromZeroBased(0));
+        commands[5] = new AddCommand(CARL);
+        commands[6] = new ListCommand();
+        commands[7] = new TagCommand(Index.fromZeroBased(1), new Tag("tag"));
+        commands[8] = new AddCommand(ELLE);
+
+        Model expectedModel = new ModelManager();
+        for (int i = 0; i <= commands.length; i++) {
+            String expectedMessage =
+                    String.format(RedoCommand.MESSAGE_SUCCESS, i, i);
+
+            Model model = new ModelManager();
+            StateHistory history = new StateHistory(model);
+            for (Command command : commands) {
+                CommandResult rs = command.execute(model);
+                history.addCommand(command, model, rs);
+            }
+            history.undo(commands.length);
+            RedoCommand redoCommand = new RedoCommand(i);
+            redoCommand.setHistory(history);
+            assertCommandSuccess(redoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
+
+            if (i < commands.length) {
+                commands[i].execute(expectedModel);
+            }
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
 
 import java.util.Collections;
@@ -17,7 +18,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.StateHistory;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.tag.Tag;
 
 public class RedoCommandTest {
 
@@ -74,7 +74,7 @@ public class RedoCommandTest {
         commands[4] = new DeleteCommand(Index.fromZeroBased(0));
         commands[5] = new AddCommand(CARL);
         commands[6] = new ListCommand();
-        commands[7] = new TagCommand(Index.fromZeroBased(1), new Tag("tag"));
+        commands[7] = new AddCommand(FIONA);
         commands[8] = new AddCommand(ELLE);
 
         Model expectedModel = new ModelManager();

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
 
 import java.util.Collections;
@@ -17,7 +18,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.StateHistory;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.tag.Tag;
 
 public class UndoCommandTest {
 
@@ -73,7 +73,7 @@ public class UndoCommandTest {
         commands[4] = new DeleteCommand(Index.fromZeroBased(0));
         commands[5] = new AddCommand(CARL);
         commands[6] = new ListCommand();
-        commands[7] = new TagCommand(Index.fromZeroBased(1), new Tag("tag"));
+        commands[7] = new AddCommand(FIONA);
         commands[8] = new AddCommand(ELLE);
 
         Model expectedModel = new ModelManager();

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,100 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.StateHistory;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
+
+public class UndoCommandTest {
+
+    @Test
+    public void execute_noCommands_success() {
+        String expectedMessage = String.format(UndoCommand.MESSAGE_SUCCESS, 0, 1);
+        Model model = new ModelManager();
+        StateHistory history = new StateHistory(model);
+        Model expectedModel = new ModelManager();
+        UndoCommand undoCommand = new UndoCommand(1);
+        undoCommand.setHistory(history);
+        assertCommandSuccess(undoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
+    }
+
+    @Test
+    public void execute_addDeleteCommands_success() throws CommandException {
+        Command[] commands = new Command[6];
+        commands[0] = new AddCommand(DANIEL);
+        commands[1] = new AddCommand(GEORGE);
+        commands[2] = new AddCommand(ALICE);
+        commands[3] = new DeleteCommand(Index.fromZeroBased(0));
+        commands[4] = new AddCommand(CARL);
+        commands[5] = new AddCommand(ELLE);
+
+        Model expectedModel = new ModelManager();
+        for (int i = 0; i <= commands.length; i++) {
+            String expectedMessage =
+                    String.format(UndoCommand.MESSAGE_SUCCESS, commands.length - i, commands.length - i);
+
+            Model model = new ModelManager();
+            StateHistory history = new StateHistory(model);
+            for (Command command : commands) {
+                CommandResult rs = command.execute(model);
+                history.addCommand(command, model, rs);
+            }
+            UndoCommand undoCommand = new UndoCommand(commands.length - i);
+            undoCommand.setHistory(history);
+            assertCommandSuccess(undoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
+
+            if (i < commands.length) {
+                commands[i].execute(expectedModel);
+            }
+        }
+    }
+
+    @Test
+    public void execute_predicateCommands_success() throws CommandException {
+        Command[] commands = new Command[9];
+        commands[0] = new AddCommand(DANIEL);
+        commands[1] = new AddCommand(GEORGE);
+        commands[2] = new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("GEORGE")));
+        commands[3] = new AddCommand(ALICE);
+        commands[4] = new DeleteCommand(Index.fromZeroBased(0));
+        commands[5] = new AddCommand(CARL);
+        commands[6] = new ListCommand();
+        commands[7] = new TagCommand(Index.fromZeroBased(1), new Tag("tag"));
+        commands[8] = new AddCommand(ELLE);
+
+        Model expectedModel = new ModelManager();
+        for (int i = 0; i <= commands.length; i++) {
+            String expectedMessage =
+                    String.format(UndoCommand.MESSAGE_SUCCESS, commands.length - i, commands.length - i);
+
+            Model model = new ModelManager();
+            StateHistory history = new StateHistory(model);
+            for (Command command : commands) {
+                CommandResult rs = command.execute(model);
+                history.addCommand(command, model, rs);
+            }
+            UndoCommand undoCommand = new UndoCommand(commands.length - i);
+            undoCommand.setHistory(history);
+            assertCommandSuccess(undoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
+
+            if (i < commands.length) {
+                commands[i].execute(expectedModel);
+            }
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -11,8 +11,8 @@ import seedu.address.logic.commands.DeleteTagCommand;
 import seedu.address.model.tag.Tag;
 
 /**
- * TagCommandParserTest is used to provide some test case for basic simple check on
- * TagCommandParser class implementation.
+ * DeleteTagCommandParserTest is used to provide some test case for basic simple check on
+ * DeleteTagCommandParser class implementation.
  */
 public class DeleteTagCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/RedoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RedoCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.RedoCommand;
+
+public class RedoCommandParserTest {
+
+    private RedoCommandParser parser = new RedoCommandParser();
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "teresa",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RedoCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noArgs_returnsRedoCommand() {
+        assertParseSuccess(parser, "", new RedoCommand(1));
+    }
+
+    @Test
+    public void parse_validArgs_returnsRedoCommand() {
+        assertParseSuccess(parser, "22", new RedoCommand(22));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UndoCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UndoCommand;
+
+public class UndoCommandParserTest {
+
+    private UndoCommandParser parser = new UndoCommandParser();
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "agnes",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noArgs_returnsUndoCommand() {
+        assertParseSuccess(parser, "", new UndoCommand(1));
+    }
+
+    @Test
+    public void parse_validArgs_returnsUndoCommand() {
+        assertParseSuccess(parser, "17", new UndoCommand(17));
+    }
+}

--- a/src/test/java/seedu/address/model/StateHistoryTest.java
+++ b/src/test/java/seedu/address/model/StateHistoryTest.java
@@ -1,0 +1,87 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.testutil.PersonBuilder;
+
+public class StateHistoryTest {
+
+    @Test
+    public void undoRedo_boundsExceeded_selfBounded() throws CommandException {
+        Model model = new ModelManager();
+        StateHistory stateHistory = new StateHistory(model);
+        for (int i = 0; i < 5; i++) {
+            AddCommand addCommand = new AddCommand(new PersonBuilder().withName(Integer.toString(i)).build());
+            CommandResult result = addCommand.execute(model);
+            stateHistory.addCommand(addCommand, model, result);
+        }
+        assertEquals(stateHistory.undo(4), 4);
+        assertEquals(stateHistory.undo(3), 1);
+        assertEquals(stateHistory.redo(5), 5);
+        assertEquals(stateHistory.redo(5), 0);
+        assertEquals(stateHistory.undo(6), 5);
+        assertEquals(stateHistory.redo(9001), 5);
+    }
+
+    @Test
+    public void undo_addCommand_correctCount() throws CommandException {
+        Model model = new ModelManager();
+        StateHistory stateHistory = new StateHistory(model);
+        for (int i = 0; i < 5; i++) {
+            AddCommand addCommand = new AddCommand(new PersonBuilder().withName(Integer.toString(i)).build());
+            CommandResult result = addCommand.execute(model);
+            stateHistory.addCommand(addCommand, model, result);
+        }
+        assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), 5);
+        for (int i = 0; i < 5; ++i) {
+            assertEquals(stateHistory.undo(1), 1);
+            assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), 5 - i - 1);
+        }
+    }
+
+    @Test
+    public void undo_exceededInterval_correctCount() throws CommandException {
+        Model model = new ModelManager();
+        StateHistory stateHistory = new StateHistory(model);
+        int N = StateHistory.HISTORY_DEFAULT_INTERVAL * 2 + 2;
+        for (int i = 0; i < N; i++) {
+            AddCommand addCommand = new AddCommand(new PersonBuilder().withName(Integer.toString(i)).build());
+            CommandResult result = addCommand.execute(model);
+            stateHistory.addCommand(addCommand, model, result);
+        }
+        assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), N);
+        for (int i = 0; i < N; ++i) {
+            assertEquals(stateHistory.undo(1), 1);
+            assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), N - i - 1);
+        }
+    }
+
+    @Test
+    public void undoRedo_splitFuture_dropOriginal() throws CommandException {
+        Model model = new ModelManager();
+        StateHistory stateHistory = new StateHistory(model);
+        for (int i = 0; i < 16; i++) {
+            AddCommand addCommand = new AddCommand(new PersonBuilder().withName(Integer.toString(i)).build());
+            CommandResult result = addCommand.execute(model);
+            stateHistory.addCommand(addCommand, model, result);
+        }
+        assertEquals(stateHistory.undo(8), 8);
+        model = stateHistory.presentModel();
+        for (int i = 8; i < 10; i++) {
+            AddCommand addCommand = new AddCommand(new PersonBuilder().withName(Integer.toString(i)).build());
+            CommandResult result = addCommand.execute(model);
+            stateHistory.addCommand(addCommand, model, result);
+        }
+        assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), 10);
+        assertEquals(stateHistory.redo(1), 0);
+        assertEquals(stateHistory.undo(20), 10);
+        assertEquals(stateHistory.redo(20), 10);
+        assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), 10);
+    }
+
+}

--- a/src/test/java/seedu/address/model/StateHistoryTest.java
+++ b/src/test/java/seedu/address/model/StateHistoryTest.java
@@ -48,16 +48,16 @@ public class StateHistoryTest {
     public void undo_exceededInterval_correctCount() throws CommandException {
         Model model = new ModelManager();
         StateHistory stateHistory = new StateHistory(model);
-        int N = StateHistory.HISTORY_DEFAULT_INTERVAL * 2 + 2;
-        for (int i = 0; i < N; i++) {
+        int n = StateHistory.HISTORY_DEFAULT_INTERVAL * 2 + 2;
+        for (int i = 0; i < n; i++) {
             AddCommand addCommand = new AddCommand(new PersonBuilder().withName(Integer.toString(i)).build());
             CommandResult result = addCommand.execute(model);
             stateHistory.addCommand(addCommand, model, result);
         }
-        assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), N);
-        for (int i = 0; i < N; ++i) {
+        assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), n);
+        for (int i = 0; i < n; ++i) {
             assertEquals(stateHistory.undo(1), 1);
-            assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), N - i - 1);
+            assertEquals(stateHistory.presentModel().getAddressBook().getPersonList().size(), n - i - 1);
         }
     }
 


### PR DESCRIPTION
Add Undo command

- Undoes the last command/last _n_ commands that can be undone
- (currently all commands excluding `export`, `help`, other `undo`s and `redo`s; UI options)
- Does not persist upon exit & relaunch

Add Redo command

- Redoes the last undone command/last _n_ undone commands

Miscellaneous naming/documentation fixes