### PR TITLE
Add Freeze & Unfreeze Commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FreezeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FreezeCommand.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.exceptions.ModifyFrozenStateException;
+
+/**
+ * Freezes the address book.
+ */
+public class FreezeCommand extends Command {
+
+    public static final List<String> COMMAND_WORDS = List.of(new String[]{"freeze", "frz"});
+    public static final String MESSAGE_SUCCESS = "Address book has been frozen!";
+    public static final String MESSAGE_FAILURE = "Address book is already frozen!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        try {
+            model.freezeFilteredPersonList();
+        } catch (ModifyFrozenStateException ex) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+        return new CommandResult(MESSAGE_SUCCESS, true, true);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -46,6 +46,9 @@ public class RedoCommand extends Command {
         Model redoneModel = history.presentModel();
         model.setAddressBook(redoneModel.getAddressBook());
         model.updateFilteredPersonList(redoneModel.getPredicate());
+        if (redoneModel.isFrozen()) {
+            model.freezeWith(redoneModel.getFilteredPersonList());
+        }
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, redoneCommands, numCommands), false, false);
     }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -46,6 +46,9 @@ public class UndoCommand extends Command {
         Model undoneModel = history.presentModel();
         model.setAddressBook(undoneModel.getAddressBook());
         model.updateFilteredPersonList(undoneModel.getPredicate());
+        if (undoneModel.isFrozen()) {
+            model.freezeWith(undoneModel.getFilteredPersonList());
+        }
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, undoneCommands, numCommands), false, false);
     }

--- a/src/main/java/seedu/address/logic/commands/UnfreezeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfreezeCommand.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.exceptions.ModifyFrozenStateException;
+
+/**
+ * Unfreezes the address book.
+ */
+public class UnfreezeCommand extends Command {
+
+    public static final List<String> COMMAND_WORDS = List.of(new String[]{"unfreeze", "unf"});
+    public static final String MESSAGE_SUCCESS = "Address book has been unfrozen!";
+    public static final String MESSAGE_FAILURE = "Address book is not frozen!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        try {
+            model.unfreezeFilteredPersonList();
+        } catch (ModifyFrozenStateException ex) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+        return new CommandResult(MESSAGE_SUCCESS, true, true);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FreezeCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -23,6 +24,7 @@ import seedu.address.logic.commands.MassOpCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.UnfreezeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -64,6 +66,10 @@ public class AddressBookParser {
             return new ClearCommand();
         } else if (FilterCommand.COMMAND_WORDS.contains(commandWord)) {
             return new FilterCommandParser().parse(arguments);
+        } else if (FreezeCommand.COMMAND_WORDS.contains(commandWord)) {
+            return new FreezeCommand();
+        } else if (UnfreezeCommand.COMMAND_WORDS.contains(commandWord)) {
+            return new UnfreezeCommand();
         } else if (UndoCommand.COMMAND_WORDS.contains(commandWord)) {
             return new UndoCommandParser().parse(arguments);
         } else if (RedoCommand.COMMAND_WORDS.contains(commandWord)) {

--- a/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTagCommandParser.java
@@ -35,9 +35,9 @@ public class DeleteTagCommandParser implements Parser<DeleteTagCommand> {
             Tag tag = ParserUtil.parseTag(nameKeywords[TAG_INDEX]);
 
             return new DeleteTagCommand(index, tag);
-        } catch (ParseException pe) {
+        } catch (ParseException | ArrayIndexOutOfBoundsException e) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE), e);
         }
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,10 +1,12 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.exceptions.ModifyFrozenStateException;
 import seedu.address.model.history.History;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
@@ -86,6 +88,14 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<? super Person> predicate);
+
+    void freezeFilteredPersonList() throws ModifyFrozenStateException;
+
+    void unfreezeFilteredPersonList() throws ModifyFrozenStateException;
+
+    void freezeWith(List<Person> frozenPersons);
+
+    boolean isFrozen();
 
     Predicate<? super Person> getPredicate();
 

--- a/src/main/java/seedu/address/model/exceptions/ModifyFrozenStateException.java
+++ b/src/main/java/seedu/address/model/exceptions/ModifyFrozenStateException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.exceptions;
+
+/**
+ * Represents a failure to freeze or unfreeze a Model, due to it already being frozen or unfrozen.
+ */
+public class ModifyFrozenStateException extends Exception {
+
+    public ModifyFrozenStateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/address/model/person/ParticularPersonsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ParticularPersonsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Tests for equality against at least one of a supplied list of {@code Person}s.
+ */
+public class ParticularPersonsPredicate implements Predicate<Person> {
+    private final List<Person> persons;
+
+    /**
+     * Creates a ParticularPersonsPredicate matching any Person equal to an element in {@code persons}.
+     *
+     * @param persons Persons to match against
+     */
+    public ParticularPersonsPredicate(List<Person> persons) {
+        this.persons = persons;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return persons.contains(person);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ParticularPersonsPredicate // instanceof handles nulls
+                && Objects.equals(persons, ((ParticularPersonsPredicate) other).persons)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -101,8 +101,6 @@ public class Person implements DeepCopyable<Person> {
      * Deep copies the current person.
      */
     public Person deepCopy() {
-        Set<Tag> copy = new HashSet<>();
-        copy.addAll(tags);
         return new Person(name, phone, email, address, income, tags);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.exceptions.ModifyFrozenStateException;
 import seedu.address.model.history.History;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
@@ -158,6 +160,26 @@ public class AddCommandTest {
         @Override
         public void updateFilteredPersonList(Predicate<? super Person> predicate) {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void freezeFilteredPersonList() throws ModifyFrozenStateException {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public void unfreezeFilteredPersonList() throws ModifyFrozenStateException {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public void freezeWith(List<Person> frozenPersons) {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public boolean isFrozen() {
+            throw new AssertionError("This method should not be called");
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/FreezeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FreezeCommandTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.exceptions.ModifyFrozenStateException;
+import seedu.address.model.person.FieldsMatchRegexPredicate;
+import seedu.address.model.person.ParticularPersonsPredicate;
+import seedu.address.model.tag.Tag;
+
+public class FreezeCommandTest {
+
+    @Test
+    public void execute_predicateMatchesChanged_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        FieldsMatchRegexPredicate tagPredicate = new FieldsMatchRegexPredicate(
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                Collections.singletonList("owesMoney")
+        );
+        model.updateFilteredPersonList(tagPredicate);
+        expectedModel.updateFilteredPersonList(
+                new ParticularPersonsPredicate(
+                        Collections.singletonList(expectedModel.getFilteredPersonList().get(1))));
+        FreezeCommand freezeCommand = new FreezeCommand();
+        assertCommandSuccess(freezeCommand, model,
+                new CommandResult(FreezeCommand.MESSAGE_SUCCESS, true, true), expectedModel);
+        model.deleteTag(BENSON, new Tag("owesMoney"));
+        expectedModel.deleteTag(BENSON, new Tag("owesMoney"));
+        assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_alreadyFrozen_throwsException() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        FreezeCommand freezeCommand = new FreezeCommand();
+        try {
+            model.freezeFilteredPersonList();
+        } catch (ModifyFrozenStateException ex) {
+            throw new AssertionError("Freezing failed on new model", ex);
+        }
+        assertCommandFailure(freezeCommand, model, FreezeCommand.MESSAGE_FAILURE);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -2,12 +2,14 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.StateHistory;
+import seedu.address.model.person.FieldsMatchRegexPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
 
 public class RedoCommandTest {
 
@@ -64,21 +68,51 @@ public class RedoCommandTest {
         }
     }
 
+    private Command[] predicateCommands() {
+        Command[] commands = new Command[18];
+        commands[0] = new AddCommand(DANIEL.deepCopy());
+        commands[1] = new AddCommand(GEORGE.deepCopy());
+        commands[2] = new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("GEORGE")));
+        commands[3] = new AddCommand(ALICE.deepCopy());
+        commands[4] = new DeleteCommand(Index.fromZeroBased(0));
+        commands[5] = new AddCommand(CARL.deepCopy());
+        commands[6] = new ListCommand();
+        commands[7] = new AddCommand(FIONA.deepCopy());
+        commands[8] = new AddCommand(ELLE.deepCopy());
+        commands[9] = new FilterCommand(new FieldsMatchRegexPredicate(
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                Collections.singletonList("friends")
+        ));
+        commands[10] = new FreezeCommand();
+        commands[11] = new AddCommand(BENSON.deepCopy());
+        commands[12] = new ListCommand();
+        commands[13] = new TagCommand(Index.fromZeroBased(3), new Tag("friends"));
+        commands[14] = new FilterCommand(new FieldsMatchRegexPredicate(
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                Collections.singletonList("friends")
+        ));
+        commands[15] = new FreezeCommand();
+        commands[16] = new DeleteTagCommand(Index.fromZeroBased(2), new Tag("friends"));
+        commands[17] = new UnfreezeCommand();
+        return commands;
+    }
+
     @Test
     public void execute_predicateCommands_success() throws CommandException {
-        Command[] commands = new Command[9];
-        commands[0] = new AddCommand(DANIEL);
-        commands[1] = new AddCommand(GEORGE);
-        commands[2] = new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("GEORGE")));
-        commands[3] = new AddCommand(ALICE);
-        commands[4] = new DeleteCommand(Index.fromZeroBased(0));
-        commands[5] = new AddCommand(CARL);
-        commands[6] = new ListCommand();
-        commands[7] = new AddCommand(FIONA);
-        commands[8] = new AddCommand(ELLE);
+        Command[] referenceCommands = predicateCommands();
 
         Model expectedModel = new ModelManager();
-        for (int i = 0; i <= commands.length; i++) {
+        for (int i = 0; i <= referenceCommands.length; i++) {
+            Command[] commands = predicateCommands();
+
             String expectedMessage =
                     String.format(RedoCommand.MESSAGE_SUCCESS, i, i);
 
@@ -93,8 +127,8 @@ public class RedoCommandTest {
             redoCommand.setHistory(history);
             assertCommandSuccess(redoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
 
-            if (i < commands.length) {
-                commands[i].execute(expectedModel);
+            if (i < referenceCommands.length) {
+                referenceCommands[i].execute(expectedModel);
             }
         }
     }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -2,12 +2,14 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.StateHistory;
+import seedu.address.model.person.FieldsMatchRegexPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
 
 public class UndoCommandTest {
 
@@ -63,21 +67,51 @@ public class UndoCommandTest {
         }
     }
 
+    private Command[] predicateCommands() {
+        Command[] commands = new Command[18];
+        commands[0] = new AddCommand(DANIEL.deepCopy());
+        commands[1] = new AddCommand(GEORGE.deepCopy());
+        commands[2] = new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("GEORGE")));
+        commands[3] = new AddCommand(ALICE.deepCopy());
+        commands[4] = new DeleteCommand(Index.fromZeroBased(0));
+        commands[5] = new AddCommand(CARL.deepCopy());
+        commands[6] = new ListCommand();
+        commands[7] = new AddCommand(FIONA.deepCopy());
+        commands[8] = new AddCommand(ELLE.deepCopy());
+        commands[9] = new FilterCommand(new FieldsMatchRegexPredicate(
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                Collections.singletonList("friends")
+        ));
+        commands[10] = new FreezeCommand();
+        commands[11] = new AddCommand(BENSON.deepCopy());
+        commands[12] = new ListCommand();
+        commands[13] = new TagCommand(Index.fromZeroBased(3), new Tag("friends"));
+        commands[14] = new FilterCommand(new FieldsMatchRegexPredicate(
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                Collections.singletonList("friends")
+        ));
+        commands[15] = new FreezeCommand();
+        commands[16] = new DeleteTagCommand(Index.fromZeroBased(2), new Tag("friends"));
+        commands[17] = new UnfreezeCommand();
+        return commands;
+    }
+
     @Test
     public void execute_predicateCommands_success() throws CommandException {
-        Command[] commands = new Command[9];
-        commands[0] = new AddCommand(DANIEL);
-        commands[1] = new AddCommand(GEORGE);
-        commands[2] = new FindCommand(new NameContainsKeywordsPredicate(Collections.singletonList("GEORGE")));
-        commands[3] = new AddCommand(ALICE);
-        commands[4] = new DeleteCommand(Index.fromZeroBased(0));
-        commands[5] = new AddCommand(CARL);
-        commands[6] = new ListCommand();
-        commands[7] = new AddCommand(FIONA);
-        commands[8] = new AddCommand(ELLE);
-
         Model expectedModel = new ModelManager();
-        for (int i = 0; i <= commands.length; i++) {
+        Command[] referenceCommands = predicateCommands();
+
+        for (int i = 0; i <= referenceCommands.length; i++) {
+            Command[] commands = predicateCommands();
+
             String expectedMessage =
                     String.format(UndoCommand.MESSAGE_SUCCESS, commands.length - i, commands.length - i);
 
@@ -91,8 +125,8 @@ public class UndoCommandTest {
             undoCommand.setHistory(history);
             assertCommandSuccess(undoCommand, model, new CommandResult(expectedMessage, false, false), expectedModel);
 
-            if (i < commands.length) {
-                commands[i].execute(expectedModel);
+            if (i < referenceCommands.length) {
+                referenceCommands[i].execute(expectedModel);
             }
         }
     }

--- a/src/test/java/seedu/address/logic/commands/UnfreezeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnfreezeCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.exceptions.ModifyFrozenStateException;
+import seedu.address.model.person.FieldsMatchRegexPredicate;
+import seedu.address.model.person.ParticularPersonsPredicate;
+import seedu.address.model.tag.Tag;
+
+public class UnfreezeCommandTest {
+
+    @Test
+    public void execute_predicateMatchesChanged_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        FieldsMatchRegexPredicate tagPredicate = new FieldsMatchRegexPredicate(
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                Collections.singletonList("owesMoney")
+        );
+        model.updateFilteredPersonList(tagPredicate);
+        expectedModel.updateFilteredPersonList(
+                new ParticularPersonsPredicate(
+                        Collections.singletonList(expectedModel.getFilteredPersonList().get(1))));
+        try {
+            model.freezeFilteredPersonList();
+        } catch (ModifyFrozenStateException ex) {
+            throw new AssertionError("Freezing failed on new model", ex);
+        }
+        model.deleteTag(BENSON, new Tag("owesMoney"));
+        expectedModel.deleteTag(BENSON, new Tag("owesMoney"));
+        assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
+
+        UnfreezeCommand unfreezeCommand = new UnfreezeCommand();
+        expectedModel.updateFilteredPersonList(tagPredicate);
+        assertCommandSuccess(unfreezeCommand, model,
+                new CommandResult(UnfreezeCommand.MESSAGE_SUCCESS, true, true), expectedModel);
+    }
+
+    @Test
+    public void execute_notFrozen_throwsException() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        UnfreezeCommand unfreezeCommand = new UnfreezeCommand();
+        assertCommandFailure(unfreezeCommand, model, UnfreezeCommand.MESSAGE_FAILURE);
+        try {
+            model.freezeFilteredPersonList();
+        } catch (ModifyFrozenStateException ex) {
+            throw new AssertionError("Freezing failed on new model", ex);
+        }
+        try {
+            unfreezeCommand.execute(model);
+        } catch (CommandException ex) {
+            throw new AssertionError("Command failed on valid model", ex);
+        }
+        assertCommandFailure(unfreezeCommand, model, UnfreezeCommand.MESSAGE_FAILURE);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteTagCommandParserTest.java
@@ -28,4 +28,10 @@ public class DeleteTagCommandParserTest {
         assertParseFailure(parser, "abei2jfsk",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_noTag_throwsParseException() {
+        assertParseFailure(parser, "2",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTagCommand.MESSAGE_USAGE));
+    }
 }


### PR DESCRIPTION
Add Freeze command

- Freezes the display list, halting any updates to it that would have occurred due to Persons no longer satisfying predicates

Add Unfreeze command

- Restores dynamic display list updates, according to the last used predicate

Fix parsing bug with Delete-Tag